### PR TITLE
Bugfix: #2

### DIFF
--- a/src/main/java/me/axerr/pingwheel/ping/PingListener.java
+++ b/src/main/java/me/axerr/pingwheel/ping/PingListener.java
@@ -31,7 +31,7 @@ public class PingListener implements PluginMessageListener {
 
         if(!canPlayerUsePing(ping)) return false;
         if(!isPingWithinXYZLimits(ping)) return false;
-        if(!isInsidePingableWorldGuardRegion(ping)) {
+        if(Config.WORLDGUARD_ENABLED && !isInsidePingableWorldGuardRegion(ping)) {
             sendMessage(player, Config.WORLDGUARD_DENY_MESSAGE);
             return false;
         }


### PR DESCRIPTION
If world guard was not installed on the server this method would throw an exception ( class not found, Issue #2 ).
By checking whether it is enabled one can get around that.